### PR TITLE
Skip non-existent fixers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     "require": {
         "php": ">=5.3",
         "symfony/yaml": "~2.3",
-        "symfony/dependency-injection": "~2.3"
+        "symfony/dependency-injection": "~2.3",
+        "symfony/console": "~2.3"
     },
     "require-dev": {
-        "symfony/console": "~2.7",
         "twig/twig": "~1.22",
         "fabpot/php-cs-fixer": "~1.9",
         "satooshi/php-coveralls": "~0.6",


### PR DESCRIPTION
PHP-CS-Fixer does not authorize non-existent fixers.

This system will prevent adding them and warn the developer of skipped fixers.

Fixes #19.