### PR TITLE
StyleCI/Config usage

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -15,5 +15,3 @@ disabled:
 finder:
   not-name:
     - "*.php.twig"
-  not-path:
-    - "src/StyleCI/Fixers.php"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - nightly
@@ -16,7 +13,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
+    - php: 5.6
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
       env: PHP_CS_FIXER_VERSION=1.*
@@ -42,11 +39,7 @@ before_script:
   - if [ "$PHP_CS_FIXER_VERSION" != "" ]; then composer require "fabpot/php-cs-fixer:${PHP_CS_FIXER_VERSION}" --no-update; fi;
   - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
-script:
-  - make test
-  # Nightly builded with https://nightli.es/
-  # See also: https://github.com/travis-ci/travis-ci/issues/582#issuecomment-124136045
-  - ./bridge styleci:config:check
+script: make test
 
 after_script:
   - php vendor/bin/coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3",
+        "php": ">=5.6",
         "symfony/yaml": "~2.3",
         "symfony/config": "~2.3",
         "symfony/dependency-injection": "~2.3",
-        "symfony/console": "~2.3"
+        "symfony/console": "~2.3",
+        "styleci/config": "~2.2"
     },
     "require-dev": {
         "twig/twig": "~1.22",

--- a/src/ConfigBridge.php
+++ b/src/ConfigBridge.php
@@ -5,6 +5,8 @@ namespace SLLH\StyleCIBridge;
 use SLLH\StyleCIBridge\Exception\LevelConfigException;
 use SLLH\StyleCIBridge\StyleCI\Configuration;
 use SLLH\StyleCIBridge\StyleCI\Fixers;
+use SLLH\StyleCIBridge\StyleCI\Presets;
+use StyleCI\Config\Config as StyleCIConfig;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -215,7 +217,7 @@ final class ConfigBridge
     private function getPresetFixers()
     {
         $preset = $this->styleCIConfig['preset'];
-        $validPresets = Fixers::getPresets();
+        $validPresets = Presets::all();
 
         return $validPresets[$preset];
     }
@@ -230,7 +232,7 @@ final class ConfigBridge
      */
     private function resolveAliases(array $fixers)
     {
-        foreach (Fixers::$aliases as $alias => $name) {
+        foreach (StyleCIConfig::ALIASES as $alias => $name) {
             if (in_array($alias, $fixers, true) && !in_array($name, $fixers, true) && $this->isFixerAvailable($name)) {
                 array_push($fixers, $name);
             }

--- a/src/StyleCI/Configuration.php
+++ b/src/StyleCI/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace SLLH\StyleCIBridge\StyleCI;
 
+use StyleCI\Config\Config as StyleCIConfig;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -18,13 +19,13 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('styleci');
 
-        $validFixers = array_merge(Fixers::$valid, array_keys(Fixers::$aliases));
+        $validFixers = array_merge(StyleCIConfig::VALID, array_keys(StyleCIConfig::ALIASES));
 
         $rootNode
             ->children()
                 ->enumNode('preset')
                     ->isRequired()
-                    ->values(array_keys(Fixers::getPresets()))
+                    ->values(array_keys(Presets::all()))
                 ->end()
                 ->booleanNode('linting')
                     ->defaultTrue()
@@ -76,13 +77,13 @@ final class Configuration implements ConfigurationInterface
             ->end()
             ->validate()
                 ->ifTrue(function ($config) {
-                    $presets = Fixers::getPresets();
+                    $presets = Presets::all();
                     $enabledFixers = array_merge($presets[$config['preset']], $config['enabled']);
                     $disabledFixers = $config['disabled'];
                     $fixers = array_diff($enabledFixers, $disabledFixers);
 
                     // See: https://github.com/StyleCI/Config/blob/f9747aba632aa4d272f212b5b9c9942234f4f074/src/Config.php#L549-L553
-                    foreach (Fixers::$conflicts as $first => $second) {
+                    foreach (StyleCIConfig::CONFLICTS as $first => $second) {
                         if (in_array($first, $fixers, true) && in_array($second, $fixers, true)) {
                             return true;
                         }

--- a/src/StyleCI/Fixers.php
+++ b/src/StyleCI/Fixers.php
@@ -2,10 +2,13 @@
 
 namespace SLLH\StyleCIBridge\StyleCI;
 
+@trigger_error('SLLH\StyleCIBridge\StyleCI\Fixers class is deprecated since x.y and will be removed in x.0', E_USER_DEPRECATED);
+
 /**
  * This class was auto-generated from StyleCI/Config repository.
  *
  * @link https://github.com/StyleCI/Config/blob/master/src/Config.php
+ * @deprecated
  */
 class Fixers
 {
@@ -106,7 +109,6 @@ class Fixers
         'whitespacy_lines',
     );
 
-
     /**
      * @var string[]
      */
@@ -115,7 +117,6 @@ class Fixers
         'psr4',
         'short_tag',
     );
-
 
     /**
      * @var string[]
@@ -142,7 +143,6 @@ class Fixers
         'trailing_spaces',
         'visibility',
     );
-
 
     /**
      * @var string[]
@@ -220,7 +220,6 @@ class Fixers
         'whitespacy_lines',
     );
 
-
     /**
      * @var string[]
      */
@@ -293,7 +292,6 @@ class Fixers
         'visibility',
         'whitespacy_lines',
     );
-
 
     /**
      * @var string[]
@@ -373,7 +371,6 @@ class Fixers
         'whitespacy_lines',
     );
 
-
     /**
      * @var string[]
      */
@@ -382,27 +379,28 @@ class Fixers
         'join_function' => 'alias_functions',
     );
 
-
     /**
      * @var string[]
      */
     public static $conflicts = array(
-        'concat_with_spaces' => 'concat_without_spaces',
-        'long_array_syntax' => 'short_array_syntax',
+        'concat_with_spaces'              => 'concat_without_spaces',
+        'long_array_syntax'               => 'short_array_syntax',
         'no_blank_lines_before_namespace' => 'single_blank_line_before_namespace',
-        'phpdoc_var_to_type' => 'phpdoc_type_to_var',
-        'psr0' => 'psr4',
-        'unalign_double_arrow' => 'align_double_arrow',
-        'unalign_equals' => 'align_equals',
+        'phpdoc_var_to_type'              => 'phpdoc_type_to_var',
+        'psr0'                            => 'psr4',
+        'unalign_double_arrow'            => 'align_double_arrow',
+        'unalign_equals'                  => 'align_equals',
     );
 
     public static function getPresets()
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since x.y and will be removed in x.0', E_USER_DEPRECATED);
+
         return array(
-            'psr1' => self::$psr1_fixers,
-            'psr2' => self::$psr2_fixers,
-            'symfony' => self::$symfony_fixers,
-            'laravel' => self::$laravel_fixers,
+            'psr1'        => self::$psr1_fixers,
+            'psr2'        => self::$psr2_fixers,
+            'symfony'     => self::$symfony_fixers,
+            'laravel'     => self::$laravel_fixers,
             'recommended' => self::$recommended_fixers,
         );
     }

--- a/src/StyleCI/Presets.php
+++ b/src/StyleCI/Presets.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SLLH\StyleCIBridge\StyleCI;
+
+use StyleCI\Config\Config as StyleCIConfig;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class Presets
+{
+    public static function all()
+    {
+        return array(
+            'psr1'        => StyleCIConfig::PSR1_FIXERS,
+            'psr2'        => StyleCIConfig::PSR2_FIXERS,
+            'symfony'     => StyleCIConfig::SYMFONY_FIXERS,
+            'laravel'     => StyleCIConfig::LARAVEL_FIXERS,
+            'recommended' => StyleCIConfig::RECOMMENDED_FIXERS,
+        );
+    }
+}


### PR DESCRIPTION
Closes #14.

- [x] Import and use StyleCI/Config on the bridge and configuration.
- [ ] Deprecate Fixers class, generator, and commands (To do when PR is going to be merged, to choose version).

This PR **must not be merged** until PHP minimum version requirement of StyleCI/Config will match requirement of PHP-CS-Fixer.
