### PR TITLE
Use composer/semver for compatibility check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "symfony/yaml": "~2.3",
         "symfony/config": "~2.3",
         "symfony/dependency-injection": "~2.3",
-        "symfony/console": "~2.3"
+        "symfony/console": "~2.3",
+        "composer/semver": "~1.0"
     },
     "require-dev": {
         "twig/twig": "~1.22",

--- a/src/ConfigBridge.php
+++ b/src/ConfigBridge.php
@@ -2,6 +2,7 @@
 
 namespace SLLH\StyleCIBridge;
 
+use Composer\Semver\Semver;
 use SLLH\StyleCIBridge\Exception\LevelConfigException;
 use SLLH\StyleCIBridge\StyleCI\Configuration;
 use SLLH\StyleCIBridge\StyleCI\Fixers;
@@ -57,7 +58,7 @@ final class ConfigBridge
      */
     public function __construct($styleCIConfigDir = null, $finderDirs = null)
     {
-        if (version_compare(Fixer::VERSION, self::CS_FIXER_MIN_VERSION, '<')) {
+        if (!Semver::satisfies(Fixer::VERSION, sprintf('>=%s', self::CS_FIXER_MIN_VERSION))) {
             throw new \RuntimeException(sprintf(
                 'PHP-CS-Fixer v%s is not supported, please upgrade to v%s or higher.',
                 Fixer::VERSION,


### PR DESCRIPTION
Fixes #35.

Works better than `version_compare` for version tags like `2.0.0-DEV`.