### PR TITLE
Improve HeaderCommentFixer usage for 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ return ConfigBridge::create();
 require_once __DIR__.'/vendor/sllh/php-cs-fixer-styleci-bridge/autoload.php';
 
 use SLLH\StyleCIBridge\ConfigBridge;
-use Symfony\CS\Fixer\Contrib\HeaderCommentFixer;
 
 $header = <<<EOF
 This file is part of the dummy package.
@@ -190,6 +189,8 @@ This file is part of the dummy package.
 This source file is subject to the MIT license that is bundled
 with this source code in the file LICENSE.
 EOF;
+
+$config = ConfigBridge::create();
 
 return $config
     ->setRules(array_merge($config->getRules(), array(


### PR DESCRIPTION
Remove unused use statement & added missing `$config` declaration in HeaderCommentFixer demo usage.